### PR TITLE
fixing chest table's transmission to chest content's table when opening Chest presenter

### DIFF
--- a/src/Chest/ChestTableWithContentPresenter.class.st
+++ b/src/Chest/ChestTableWithContentPresenter.class.st
@@ -298,10 +298,8 @@ ChestTableWithContentPresenter >> debuggerLayout [
 		  yourself
 ]
 
-{ #category : #updating }
+{ #category : #layout }
 ChestTableWithContentPresenter >> defaultLayout [
-
-	self makeChestContentsTable.
 
 	chestTableContainer
 		removeAll;
@@ -387,7 +385,7 @@ ChestTableWithContentPresenter >> initializePresenters [
 	chestContentTableContainer := SpBoxLayout newVertical
 		                              add: self chestContentTable;
 		                              yourself.
-	chestsTable selectIndex: 1.
+		
 	chestTableWithContentContainer := SpPanedLayout newHorizontal
 		                                  add: chestTableContainer;
 		                                  add: chestContentTableContainer;


### PR DESCRIPTION
fixes #10 

For an obscure reason, `#defaultLayout` was rebuilding the chest content table with an empty item list, which is why the list would appear empty when a chest presenter opened.

I remove the selection of the first chest in `#initializePresenters` because it is already done in `#connectPresenters`