### PR TITLE
Adding radio buttons in the choice presenter of the StoreCommand, to be able to choose to copy the object before storing or not

### DIFF
--- a/src/Chest-Commands/ChestStoreObjectCommand.class.st
+++ b/src/Chest-Commands/ChestStoreObjectCommand.class.st
@@ -36,23 +36,30 @@ ChestStoreObjectCommand >> buildChoicePresenter [
 
 	| choicePresenter |
 	choicePresenter := ChestTableWithContentPresenter new.
-	choicePresenter confirmButton action: [ 
-		| chest objectName |
+	choicePresenter confirmButton action: [
+		| chest objectName selectorToSendToSelection |
 		chest := choicePresenter chestsTable selectedItem.
 		objectName := choicePresenter inputField text.
-		[ 
+		selectorToSendToSelection := #yourself.
+		choicePresenter buttonShallowCopy state ifTrue: [
+			selectorToSendToSelection := #shallowCopy ].
+		choicePresenter buttonDeepCopy state ifTrue: [
+			selectorToSendToSelection := #copy ].
+		[
 		self
 			storeSelectionInChest: chest
 			withName: objectName
+			withSelector: selectorToSendToSelection
 			replacing: false ]
 			on: ChestKeyAlreadyInUseError
-			do: [ 
+			do: [
 				((choicePresenter confirm:
-					  (choicePresenter warningNamingObjectInChest: objectName)) 
-					 onAccept: [ 
+					  (choicePresenter warningNamingObjectInChest: objectName))
+					 onAccept: [
 						 self
 							 storeSelectionInChest: chest
 							 withName: objectName
+							 withSelector: selectorToSendToSelection
 							 replacing: true ]) openDialogWithParent:
 					choicePresenter chestContentTable ].
 		choicePresenter window close ].
@@ -92,9 +99,16 @@ ChestStoreObjectCommand >> storeResult: result intoChest: chest withName: object
 ]
 
 { #category : #execution }
-ChestStoreObjectCommand >> storeSelectionInChest: aChest withName: objectName replacing: replacingBoolean [
+ChestStoreObjectCommand >> storeSelectionInChest: aChest withName: objectName withSelector: selectorSentToSelectionBeforeStoring replacing: replacingBoolean [
 
-	self evaluateSelectionAndDo: [ :result | 
-		self storeResult: result intoChest: aChest withName: objectName replacing: replacingBoolean
-	]
+	self evaluateSelectionAndDo: [ :result |
+		| storedResult |
+		storedResult := result
+			                perform: selectorSentToSelectionBeforeStoring
+			                withArguments: #(  ).
+		self
+			storeResult: storedResult
+			intoChest: aChest
+			withName: objectName
+			replacing: replacingBoolean ]
 ]

--- a/src/Chest/ChestTableWithContentPresenter.class.st
+++ b/src/Chest/ChestTableWithContentPresenter.class.st
@@ -18,7 +18,10 @@ Class {
 		'chestWithContentTreeTable',
 		'chestTableWithContentContainer',
 		'activePresenter',
-		'chestWithContentTreeTableToolbar'
+		'chestWithContentTreeTableToolbar',
+		'buttonNoCopy',
+		'buttonShallowCopy',
+		'buttonDeepCopy'
 	],
 	#category : #Chest
 }
@@ -186,6 +189,24 @@ ChestTableWithContentPresenter class >> registerClasses: commandClasses toGroup:
 ChestTableWithContentPresenter >> activePresenter [
 
 	^ activePresenter
+]
+
+{ #category : #accessing }
+ChestTableWithContentPresenter >> buttonDeepCopy [
+
+	^ buttonDeepCopy
+]
+
+{ #category : #accessing }
+ChestTableWithContentPresenter >> buttonNoCopy [
+
+	^ buttonNoCopy
+]
+
+{ #category : #accessing }
+ChestTableWithContentPresenter >> buttonShallowCopy [
+
+	^ buttonShallowCopy
 ]
 
 { #category : #accessing }
@@ -402,6 +423,8 @@ ChestTableWithContentPresenter >> initializePresenters [
 	chestContentsTableToolbar := self makeChestContentsTableToolbar.
 
 	chestWithContentTreeTableToolbar := self makeChestTreeTableToolbar.
+	
+	self makeCopyRadioButtons.
 
 	self layout: self defaultLayout
 ]
@@ -604,6 +627,22 @@ ChestTableWithContentPresenter >> makeConfirmActionBar [
 		  add: confirmButton;
 		  add: cancelButton;
 		  yourself
+]
+
+{ #category : #'presenter building' }
+ChestTableWithContentPresenter >> makeCopyRadioButtons [
+
+	buttonNoCopy := self newRadioButton.
+	buttonShallowCopy := self newRadioButton.
+	buttonDeepCopy := self newRadioButton.
+
+	buttonNoCopy associatedRadioButtons: {
+			buttonShallowCopy.
+			buttonDeepCopy }.
+
+	buttonNoCopy label: 'No copy'.
+	buttonShallowCopy label: 'Shallow copy'.
+	buttonDeepCopy label: 'Deep copy'
 ]
 
 { #category : #'presenter building' }
@@ -864,6 +903,11 @@ ChestTableWithContentPresenter >> storeCommandLayout [
 		  add: (SpBoxLayout newHorizontal
 				   add: chestsTableToolbar;
 				   add: chestContentsTableToolbar;
+				   yourself);
+		  add: (SpBoxLayout newHorizontal
+				   add: buttonNoCopy;
+				   add: buttonShallowCopy;
+				   add: buttonDeepCopy;
 				   yourself);
 		  add: confirmActionBar;
 		  yourself


### PR DESCRIPTION
Fixes #14 

This is how the UI looks like (looks pretty clean to me):

![image](https://github.com/pharo-spec/Chest/assets/97704417/45fe5c3a-8365-4a9f-b561-7320918be805)

Example in practice:

![image](https://github.com/pharo-spec/Chest/assets/97704417/b30ae845-2b09-4729-8c15-faef89545c4c)

**Note of uncertainty:**

I called the third option "deep copy" but I wonder if we should really call it "deep copy".
I actually call `#copy` and, from what I see, `#copy` performs a shallow copy and then calls `#postCopy` on the shallow copy. By default, `#postCopy` returns the shallow copy so it is a hook that the user must define to copy the instance variables that should be copied.
To me, this looks like a way to implement a deep copy. However, I also saw a method called `#deepCopy` that performs a complete deep copy (except for instances of `Object`, in which case it doesn't even do a shallow copy ???) ...

What do you think about that?