### PR TITLE
using renamed classes of tools from NewTools because their former names are deprecated

### DIFF
--- a/src/Chest/ChestPresenter.class.st
+++ b/src/Chest/ChestPresenter.class.st
@@ -332,7 +332,7 @@ ChestPresenter >> initializePresenters [
 	self makeChestsTable.
 	chestContentsTable := chestTableWithContent chestContentTable.
 	self makeChestContentsTable.
-	inspector := StInspector on: (StInspectorModel on: nil).
+	inspector := StInspectorPresenter on: (StInspectorModel on: nil).
 	chestsTable selectIndex: 1.
 
 	self makeChestTreeTableContextMenu.


### PR DESCRIPTION
`StInspector` -> `StInspectorPresenter`